### PR TITLE
填补 简\繁 翻译缺失

### DIFF
--- a/overlay/lang/zh-cn.json
+++ b/overlay/lang/zh-cn.json
@@ -7,7 +7,7 @@
     "Settings": "高级设置",
     "Enable": "启用调频",
     "Uncapped Clocks": "解锁频率",
-    "Override Boost Mode": "升压模式",
+    "Boost Clock Override": "升压模式",
     "Auto CPU Boost": "自动CPU",
     "Sync ReverseNX": "同步ReverseNX",
     "Auto GPU Vmin": "自动GPU Vmin",

--- a/overlay/lang/zh-cn.json
+++ b/overlay/lang/zh-cn.json
@@ -7,7 +7,7 @@
     "Settings": "高级设置",
     "Enable": "启用调频",
     "Uncapped Clocks": "解锁频率",
-    "Boost Clock Override": "升压模式",
+    "Boost Clock Override": "强制睿频",
     "Auto CPU Boost": "自动CPU",
     "Sync ReverseNX": "同步ReverseNX",
     "Auto GPU Vmin": "自动GPU Vmin",

--- a/overlay/lang/zh-tw.json
+++ b/overlay/lang/zh-tw.json
@@ -7,7 +7,7 @@
     "Settings": "高階設定",
     "Enable": "啟用調頻",
     "Uncapped Clocks": "解鎖頻率",
-    "Boost Clock Override": "升壓模式",
+    "Boost Clock Override": "強制睿頻",
     "Auto CPU Boost": "自動CPU",
     "Sync ReverseNX": "同步ReverseNX",
     "Auto GPU Vmin": "自動GPU Vmin",

--- a/overlay/lang/zh-tw.json
+++ b/overlay/lang/zh-tw.json
@@ -7,7 +7,7 @@
     "Settings": "高階設定",
     "Enable": "啟用調頻",
     "Uncapped Clocks": "解鎖頻率",
-    "Override Boost Mode": "升壓模式",
+    "Boost Clock Override": "升壓模式",
     "Auto CPU Boost": "自動CPU",
     "Sync ReverseNX": "同步ReverseNX",
     "Auto GPU Vmin": "自動GPU Vmin",


### PR DESCRIPTION
Hello Master, I found that the `Boost Clock Override` in `zh-cn.json` `zh-tw.json` in the latest Release has not been translated. This submission fills in the missing translation text

---
> 2025/09/23(UTC+8)

After a day of trial use, I think the translation of `Boost Clock Override`, https://github.com/nangongjing1/sys-clk/commit/064c84e730c0b84551d4c30da93f59c3deb6c087 more accurate